### PR TITLE
Code cleanup + `As` & `aS` SQL keyword support

### DIFF
--- a/knexnest.js
+++ b/knexnest.js
@@ -32,7 +32,7 @@ var knexnest = function (knexQuery, listOnEmpty) {
 		var column, alias, prepend, renamed, renamedColumn;
 		
 		for (var i = 0; i < knexQuery._statements.length; i++) {
-			if (knexQuery._statements[i].grouping === undefined || knexQuery._statements[i].grouping !== 'columns') {
+			if (knexQuery._statements[i].grouping !== 'columns') {
 				continue;
 			}
 			

--- a/knexnest.js
+++ b/knexnest.js
@@ -65,7 +65,7 @@ var knexnest = function (knexQuery, listOnEmpty) {
 						renamedColumn = column.substr(0, column.indexOf('"')) + '"' + renamed + '"';
 					}
 					aliasList.push(alias);
-				} else if (column.indexOf(' AS ') !== -1 || column.indexOf(' as ') !== -1) {
+				} else if (column.toLowerCase().indexOf(' as ') !== -1) {
 					// assume the line has the format
 					//   tableNameOrAlias.columnName AS alias
 					alias = column.substr(column.lastIndexOf(' ') + 1);

--- a/knexnest.js
+++ b/knexnest.js
@@ -5,8 +5,6 @@ var NestHydrationJS = require('nesthydrationjs');
 
 /* expects a knex object and returns a promise */
 var knexnest = function (knexQuery, listOnEmpty) {
-	var deferred = q.defer();
-	
 	// structPropToColumnMap will be sorted out properly inside nest of
 	// NestHydration this just indicates if empty should be object or array
 	var structPropToColumnMap = null;
@@ -21,8 +19,7 @@ var knexnest = function (knexQuery, listOnEmpty) {
 		// wiping out the old columns
 		
 		if (knexQuery._statements === undefined) {
-			deferred.reject('knex query object not structured as expected for KnexNest: does not have _statements property');
-			return deferred.promise;
+			return q.reject('knex query object not structured as expected for KnexNest: does not have _statements property');
 		}
 		
 		var aliasList = [];
@@ -37,8 +34,7 @@ var knexnest = function (knexQuery, listOnEmpty) {
 			}
 			
 			if (knexQuery._statements[i].value === undefined) {
-				deferred.reject('knex query object not structured as expected for KnexNest: _statements item with column grouping does not have value property');
-				return deferred.promise;
+				return q.reject('knex query object not structured as expected for KnexNest: _statements item with column grouping does not have value property');
 			}
 			
 			// columns statement, use it
@@ -116,16 +112,11 @@ var knexnest = function (knexQuery, listOnEmpty) {
 		structPropToColumnMap = true;
 	}
 	
-	knexQuery
+	return knexQuery
 		.then(function (data) {
-			deferred.resolve(NestHydrationJS.nest(data, structPropToColumnMap));
-		})
-		.catch(function (err) {
-			deferred.reject(err);
+			return NestHydrationJS.nest(data, structPropToColumnMap);
 		})
 	;
-	
-	return deferred.promise;
 };
 
 knexnest.MAX_POSTGRES_COLUMN_NAME_LENGTH = 63;

--- a/knexnest.js
+++ b/knexnest.js
@@ -50,7 +50,7 @@ var knexnest = function (knexQuery, listOnEmpty) {
 				
 				if (column.substr(-1) === '"') {
 					// assume the line has the format
-					//   tableNameOrAlias.columnName  "alias"
+					//   tableNameOrAlias.columnName "alias"
 					// or
 					//   tableNameOrAlias.columnName AS "alias"
 					alias = column.slice(column.lastIndexOf('"', column.length - 2) + 1, -1);

--- a/spec/knexnest.spec.js
+++ b/spec/knexnest.spec.js
@@ -15,7 +15,7 @@ var createMockKnexQuery = function (client, queryType, data) {
 		_statements: [
 			{grouping: 'columns', value: [
 				'something.id AS "' + arr + 'shortName"',
-				'something.someproperty AS "' + arr + 'startingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName"'
+				'something.someproperty AS "' + arr + 'startingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName"'
 			]},
 			{grouping: 'otherstuff', value: ['should not show up in column list']},
 			{grouping: 'columns', value: [
@@ -23,11 +23,17 @@ var createMockKnexQuery = function (client, queryType, data) {
 			]},
 			{grouping: 'columns', value: [
 				'something.id AS ' + arr + 'anotherShortName',
-				'something.someproperty AS ' + arr + 'anotherStartingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName'
+				'something.someproperty AS ' + arr + 'anotherStartingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName'
 			]},
 			{grouping: 'columns', value: [
 				'"something".otherProperty AS "' + arr + 'quotesEverywhere"',
 				'"something".whatProperty AS ' + arr + 'quotesThereButNotHere'
+			]},
+			{grouping: 'columns', value: [
+				'something.someproperty AS ' + arr + 'aliasAfterAS',
+				'something.someproperty As ' + arr + 'aliasAfterAs',
+				'something.someproperty aS ' + arr + 'aliasAfteraS',
+				'something.someproperty as ' + arr + 'aliasAfteras'
 			]}
 		],
 		then: function (callback) {
@@ -47,41 +53,69 @@ var createMockKnexQuery = function (client, queryType, data) {
 describe('KnexNest', function () {
 	var result, error;
 	
+	var fullDataSetFromPostgres = [{
+		_shortName: '1A',
+		col_0_hortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1B',
+		_someproperty: '1C',
+		_anotherShortName: '1D',
+		col_1_hortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1E',
+		_quotesEverywhere: '1F',
+		_quotesThereButNotHere: '1G',
+		_aliasAfterAS: '1H',
+		_aliasAfterAs: '1I',
+		_aliasAfteraS: '1J',
+		_aliasAfteras: '1K'
+	}];
+	var fullDataSetFromNonPostgres = [{
+		_shortName: '1A',
+		_startingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1B',
+		_someproperty: '1C',
+		_anotherShortName: '1D',
+		_anotherStartingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1E',
+		_quotesEverywhere: '1F',
+		_quotesThereButNotHere: '1G',
+		_aliasAfterAS: '1H',
+		_aliasAfterAs: '1I',
+		_aliasAfteraS: '1J',
+		_aliasAfteras: '1K'
+	}];
+	var expectedFullDataResult = [{
+		shortName: '1A',
+		startingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1B',
+		someproperty: '1C',
+		anotherShortName: '1D',
+		anotherStartingShortOkNotSoShortGettingLongOkThisQualifiesAsALongReallyReallyLongName: '1E',
+		quotesEverywhere: '1F',
+		quotesThereButNotHere: '1G',
+		aliasAfterAS: '1H',
+		aliasAfterAs: '1I',
+		aliasAfteraS: '1J',
+		aliasAfteras: '1K'
+	}];
+	
 	var scenarioList = [
 		{
 			describe: 'column name compliance for postgres connection and knex < 0.8.0',
-			mockKnexQuery: createMockKnexQuery('Raw_PG', 'array', [
-				{_shortName: '1A', col_0_hortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', _someproperty: '1C', _anotherShortName: '1D', col_1_hortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', _quotesEverywhere: '1F', _quotesThereButNotHere: '1G'}
-			]),
+			mockKnexQuery: createMockKnexQuery('Raw_PG', 'array', fullDataSetFromPostgres),
 			listOnEmpty: undefined,
 			it: 'should map the column names',
-			expectResult: [
-				{shortName: '1A', startingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', someproperty: '1C', anotherShortName: '1D', anotherStartingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', quotesEverywhere: '1F', quotesThereButNotHere: '1G'},
-			],
+			expectResult: expectedFullDataResult,
 			expectError: null
 		},
 		{
 			describe: 'column name compliance for postgres connection and knex >= 0.8.0',
-			mockKnexQuery: createMockKnexQuery('postgres', 'array', [
-				{_shortName: '1A', col_0_hortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', _someproperty: '1C', _anotherShortName: '1D', col_1_hortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', _quotesEverywhere: '1F', _quotesThereButNotHere: '1G'}
-			]),
+			mockKnexQuery: createMockKnexQuery('postgres', 'array', fullDataSetFromPostgres),
 			listOnEmpty: undefined,
 			it: 'should map the column names',
-			expectResult: [
-				{shortName: '1A', startingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', someproperty: '1C', anotherShortName: '1D', anotherStartingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', quotesEverywhere: '1F', quotesThereButNotHere: '1G'}
-			],
+			expectResult: expectedFullDataResult,
 			expectError: null
 		},
 		{
 			describe: 'column name compliance for non-postgres connection',
-			mockKnexQuery: createMockKnexQuery('Raw', 'array', [
-				{_shortName: '1A', _startingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', _someproperty: '1C', _anotherShortName: '1D', _anotherStartingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', _quotesEverywhere: '1F', _quotesThereButNotHere: '1G'}
-			]),
+			mockKnexQuery: createMockKnexQuery('Raw', 'array', fullDataSetFromNonPostgres),
 			listOnEmpty: undefined,
 			it: 'should map the column names',
-			expectResult: [
-				{shortName: '1A', startingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1B', someproperty: '1C', anotherShortName: '1D', anotherStartingShortOkNotSoShortGettingLongOkThisQaulifiesAsALongReallyReallyLongName: '1E', quotesEverywhere: '1F', quotesThereButNotHere: '1G'}
-			],
+			expectResult: expectedFullDataResult,
 			expectError: null
 		},
 		{


### PR DESCRIPTION
Code cleanup + added support for correctly recognizing `As` & `aS` as SQL keywords when using Postgres as a back-end database for `knex`.

Just stuff I ran into while researching some `knexnest` behaviour.
